### PR TITLE
Fix picked for you

### DIFF
--- a/inc/user-accounts.php
+++ b/inc/user-accounts.php
@@ -233,7 +233,9 @@ if ( ! function_exists( 'add_to_user_data' ) ) :
 		if ( isset( $posted['_consolidated_emails_array'] ) && is_array( $posted['_consolidated_emails_array'] ) ) {
 			$user_data['_consolidated_emails_array'] = array_map( 'sanitize_email', wp_unslash( $posted['_consolidated_emails_array'] ) );
 		}
-		$all_emails[] = $user_data['user_email'];
+		if ( isset( $user_data['user_email'] ) ) {
+			$all_emails[] = $user_data['user_email'];
+		}
 		// combine all consolidated emails
 		if ( isset( $posted['_consolidated_emails'] ) && ! empty( $posted['_consolidated_emails'] ) ) {
 			// this is a cmb2 field or a rest api field
@@ -259,18 +261,24 @@ if ( ! function_exists( 'add_to_user_data' ) ) :
 		}
 
 		// make sure the array of emails is unique, and put it together in a string to pass on
-		$all_emails                        = array_unique( $all_emails );
-		$posted['_consolidated_emails']    = implode( ',', $all_emails );
-		$user_data['_consolidated_emails'] = $posted['_consolidated_emails'];
+		if ( isset( $all_emails ) ) {
+			$all_emails                        = array_unique( $all_emails );
+			$posted['_consolidated_emails']    = implode( ',', $all_emails );
+			$user_data['_consolidated_emails'] = $posted['_consolidated_emails'];
+		}
 
 		// reading preferences field
-		if ( isset( $posted['_reading_topics'] ) && ! empty( $posted['_reading_topics'] ) ) {
+		if ( array_key_exists( '_reading_topics', $posted ) && ! empty( $posted['_reading_topics'] ) ) {
 			$user_data['_reading_topics'] = $posted['_reading_topics'];
+		} elseif ( array_key_exists( '_reading_topics', $posted ) && empty( $posted['_reading_topics'] ) ) {
+			$user_data['_reading_topics'] = '';
 		}
 
 		// street address field
-		if ( isset( $posted['street_address'] ) && ! empty( $posted['street_address'] ) ) {
+		if ( array_key_exists( 'street_address', $posted ) && ! empty( $posted['street_address'] ) ) {
 			$user_data['_street_address'] = $posted['street_address'];
+		} elseif ( array_key_exists( 'street_address', $posted ) && empty( $posted['street_address'] ) ) {
+			$user_data['_street_address'] = '';
 		}
 
 		return $user_data;
@@ -316,7 +324,7 @@ if ( ! function_exists( 'save_minnpost_user_data' ) ) :
 	add_action( 'user_account_management_post_user_data_save', 'save_minnpost_user_data', 10, 2 );
 	function save_minnpost_user_data( $user_data, $existing_user_data ) {
 		// handle consolidated email addresses
-		if ( isset( $user_data['ID'] ) && isset( $user_data['_consolidated_emails'] ) && '' !== $user_data['_consolidated_emails'] ) {
+		if ( isset( $user_data['ID'] ) && array_key_exists( '_consolidated_emails', $user_data ) && '' !== $user_data['_consolidated_emails'] ) {
 			$all_emails = array_map( 'trim', explode( ',', $user_data['_consolidated_emails'] ) );
 		}
 
@@ -332,14 +340,18 @@ if ( ! function_exists( 'save_minnpost_user_data' ) ) :
 			update_user_meta( $user_data['ID'], '_consolidated_emails', $all_emails );
 		}
 
-		// reading preferences field
-		if ( isset( $user_data['ID'] ) && isset( $user_data['_reading_topics'] ) && '' !== $user_data['_reading_topics'] ) {
+		// reading preferences field. allow it to be emptied.
+		if ( isset( $user_data['ID'] ) && array_key_exists( '_reading_topics', $user_data ) && '' !== $user_data['_reading_topics'] ) {
 			update_user_meta( $user_data['ID'], '_reading_topics', $user_data['_reading_topics'] );
+		} elseif ( isset( $user_data['ID'] ) && array_key_exists( '_reading_topics', $user_data ) && '' === $user_data['_reading_topics'] ) {
+			update_user_meta( $user_data['ID'], '_reading_topics', array() );
 		}
 
-		// street address field
-		if ( isset( $user_data['_street_address'] ) ) {
+		// street address field. allow it to be emptied.
+		if ( isset( $user_data['ID'] ) && array_key_exists( '_street_address', $user_data ) && '' !== $user_data['_street_address'] ) {
 			update_user_meta( $user_data['ID'], '_street_address', $user_data['_street_address'] );
+		} elseif ( isset( $user_data['ID'] ) && array_key_exists( '_street_address', $user_data ) && '' === $user_data['_street_address'] ) {
+			update_user_meta( $user_data['ID'], '_street_address', '' );
 		}
 	}
 endif;

--- a/inc/widgets/picked-for-you.php
+++ b/inc/widgets/picked-for-you.php
@@ -11,7 +11,7 @@ if ( ! function_exists( 'minnpost_largo_user_has_topics' ) ) :
 		if ( 0 === $user_id ) {
 			return false;
 		}
-		$user_topics = get_user_meta( $user_id, '_reading_topics', true );
+		$user_topics = maybe_unserialize( get_user_meta( $user_id, '_reading_topics', true ) );
 		if ( '' === $user_topics || ! is_array( $user_topics ) ) {
 			return false;
 		} else {
@@ -37,10 +37,13 @@ if ( ! function_exists( 'minnpost_largo_picked_for_you' ) ) :
 			}
 		}
 
-		$user_topics = get_user_meta( $user_id, '_reading_topics', true );
-		foreach ( $user_topics as $name ) {
-			$category_id        = get_cat_ID( $name );
-			$query_categories[] = $category_id;
+		$user_topics = maybe_unserialize( get_user_meta( $user_id, '_reading_topics', true ) );
+		foreach ( $user_topics as $topic ) {
+			$term = get_term_by( 'slug', sanitize_title( $topic ), 'category' );
+			if ( false !== $term ) {
+				$cat_id             = $term->term_id;
+				$query_categories[] = $cat_id;
+			}
 		}
 
 		if ( $title ) {

--- a/user-account-management-templates/front-end/account-info.php
+++ b/user-account-management-templates/front-end/account-info.php
@@ -9,7 +9,7 @@
 <section class="o-user-section o-story-recommendations">
 	<h2 class="a-user-section-title">Story recommendations for you</h2>
 	<?php if ( ! empty( $attributes['reading_topics'] ) ) : ?>
-		<p class="a-has-interests"><strong>Based on Your Interests:</strong> <span class="interests"><?php echo implode( ', ', array_values( $attributes['reading_topics'] ) ); ?></span> | <a href="/user/41043/edit/preferences?destination=user%2F41043%2Fview">Edit interests</a></p>
+		<p class="a-has-interests"><strong>Based on Your Interests:</strong> <span class="interests"><?php echo implode( ', ', array_values( $attributes['reading_topics'] ) ); ?></span> | <a href="<?php echo site_url( '/user/preferences/' ); ?>">Edit interests</a></p>
 		<div class="m-interest-posts">
 			<ul>
 			<?php

--- a/user-account-management-templates/front-end/account-preferences-form.php
+++ b/user-account-management-templates/front-end/account-preferences-form.php
@@ -5,6 +5,7 @@
 	<input type="hidden" name="user_account_management_action" value="account-settings-update">
 	<input type="hidden" name="user_account_management_redirect" value="<?php echo $attributes['redirect']; ?>">
 	<input type="hidden" name="user_account_management_account_settings_nonce" value="<?php echo wp_create_nonce( 'uam-account-settings-nonce' ); ?>">
+	<input type="hidden" name="_reading_topics" value="">
 
 	<?php if ( ! empty( $attributes['instructions'] ) ) : ?>
 		<?php echo $attributes['instructions']; ?>


### PR DESCRIPTION
This fixes #41. Things it solves:

1. Broken hardcoded link to set interests
2. WP Query used to get posts for the user's interests
3. Users accidentally clearing out account fields when updating their preferences
4. Allows empty reading topics