### PR TITLE
preventing deleted posts from being queued up if they are blacklisted

### DIFF
--- a/inc/jetpack.php
+++ b/inc/jetpack.php
@@ -120,3 +120,24 @@ if ( ! function_exists( 'minnpost_largo_jetpack_remove' ) ) :
 		}
 	}
 endif;
+
+use Automattic\Jetpack\Sync\Settings;
+
+/**
+ * Filter all blacklisted post types.
+ *
+ * @param array $args Hook arguments.
+ * @return array|false Hook arguments, or false if the post type is a blacklisted one.
+ */
+if ( ! function_exists( 'wpvip_filter_blacklisted_post_types_deleted' ) ) :
+	add_filter( 'jetpack_sync_before_enqueue_deleted_post', 'wpvip_filter_blacklisted_post_types_deleted' );
+	function wpvip_filter_blacklisted_post_types_deleted( $args ) {
+		$post = get_post( $args[0] );
+		if ( ! is_wp_error( $post ) && ! empty( $post ) ) {
+			if ( in_array( $post->post_type, Settings::get_setting( 'post_types_blacklist' ), true ) ) {
+				return false;
+			}
+		}
+		return $args;
+	}
+endif;


### PR DESCRIPTION
From VIP:
> What this is doing is hooking into the deleted_post jetpack sync hook and if the post type has been blacklisted, preventing those posts from being queued up. This should allow you to keep clearing out the logs and not see the spikes in sync which cause problems with the ES index.